### PR TITLE
Fix crash in GetNormalizedPositionOfCellAt when content not scrollable

### DIFF
--- a/Assets/UIKit/UITableView/UITableView.cs
+++ b/Assets/UIKit/UITableView/UITableView.cs
@@ -813,12 +813,15 @@ namespace UIKit
 				default: throw new ArgumentOutOfRangeException();
 			}
 
-			var deltaSize = _content.rect.size - _viewport.rect.size;
-			var normalizedPosition = _scrollRect.normalizedPosition;
-			switch (_direction) {
-				case UITableViewDirection.TopToBottom:
-					position += displacement;
-					normalizedPosition.y = 1f - position / deltaSize.y;
+                        var deltaSize = _content.rect.size - _viewport.rect.size;
+                        var normalizedPosition = _scrollRect.normalizedPosition;
+                        if ((_direction.IsVertical() && Mathf.Approximately(deltaSize.y, 0f)) ||
+                            (!_direction.IsVertical() && Mathf.Approximately(deltaSize.x, 0f)))
+                                return normalizedPosition;
+                        switch (_direction) {
+                                case UITableViewDirection.TopToBottom:
+                                        position += displacement;
+                                        normalizedPosition.y = 1f - position / deltaSize.y;
 					break;
 				case UITableViewDirection.BottomToTop:
 					position -= displacement;


### PR DESCRIPTION
## Summary
- avoid divide-by-zero in GetNormalizedPositionOfCellAt()

## Testing
- `npm test` *(fails: package.json missing)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68711bad603c8330a151e9bee9494a60