### PR TITLE
Fix README typos and headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ UITableViewForUnity will help you to develop various of list views effectively w
 
 # Installation
 
-## UMP
+## UPM
 1. Open the Unity Package Manager.
 2. Select "Add package from git URL".
 3. Enter https://github.com/zhaozilong1988/UITableViewForUnity.git?path=Assets/UIKit.
 
-## .unitypackge
-Download the unitypackge from the [Releases](https://github.com/zhaozilong1988/UITableViewForUnity/releases), then import it to your project.
+## .unitypackage
+Download the unitypackage from the [Releases](https://github.com/zhaozilong1988/UITableViewForUnity/releases), then import it to your project.
 
 # How to use?
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -55,12 +55,12 @@ Cell的高度可以被任意调整（除了0），所以像上边提到的可展
 
 # 安装
 
-## UMP
+## UPM
 1. 打开 Unity Package Manager。
 2. 选择 "Add package from git URL".
 3. 输入以下 URL：https://github.com/zhaozilong1988/UITableViewForUnity.git?path=Assets/UIKit.
 
-## .unitypackge
+## .unitypackage
 在[Releases](https://github.com/zhaozilong1988/UITableViewForUnity/releases)页面下载unitypackage文件并导入到Unity项目中。
 
 # 使用方法

--- a/README_jp.md
+++ b/README_jp.md
@@ -56,12 +56,12 @@ Cellの高さを自由(0不可)に調整できるので、ジャバラ式みた�
 
 # インストール
 
-## UMP
+## UPM
 1. Unity Package Manager を開きます。
 2. 「Add package from git URL」を選択します。
 3. 次の URL を入力します：https://github.com/zhaozilong1988/UITableViewForUnity.git?path=Assets/UIKit.
 
-## .unitypackge
+## .unitypackage
 [Releases](https://github.com/zhaozilong1988/UITableViewForUnity/releases)からunitypackageファイルをダウンロードして、プロジェクトにインポートします。
 
 # 使い方


### PR DESCRIPTION
## Summary
- fix the package installation heading from `UMP` to `UPM`
- correct `unitypackge` typos in README, README_cn, README_jp

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68711d5dd1dc833084b30fcc98716c9a