### PR TITLE
Add looping option for UITableView with sample

### DIFF
--- a/Assets/UIKit/Samples/8_LoopTable.meta
+++ b/Assets/UIKit/Samples/8_LoopTable.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e3bf7a97170b4e42b2e43a0f0883e8c1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/UIKit/Samples/8_LoopTable/8_LoopTableScene.unity
+++ b/Assets/UIKit/Samples/8_LoopTable/8_LoopTableScene.unity
@@ -1,0 +1,981 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 0
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 0
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 1563366965}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &665227619
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 665227623}
+  - component: {fileID: 665227622}
+  - component: {fileID: 665227621}
+  - component: {fileID: 665227620}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &665227620
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 665227619}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &665227621
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 665227619}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 750, y: 1334}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 1
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &665227622
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 665227619}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &665227623
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 665227619}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1465980652}
+  - {fileID: 1413112495}
+  m_Father: {fileID: 1195574257}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!1 &1195574256
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1195574257}
+  - component: {fileID: 1195574258}
+  m_Layer: 0
+  m_Name: LoopingTableScene
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1195574257
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1195574256}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 665227623}
+  - {fileID: 1257669869}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1195574258
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1195574256}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 212b90bbc3c0467da185f68c936e1a07, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _tableView: {fileID: 1413112500}
+  _cellPrefab: {fileID: 5887424805224709749, guid: c615b583c613a4e55bbde8b22f4f5451,
+    type: 3}
+  _iconSprites:
+  - {fileID: 21300000, guid: 5436ffa35601a4b2bb478f7d68e1d512, type: 3}
+  - {fileID: 21300000, guid: 25a792a840137466cb9ff7ab0e1ff687, type: 3}
+  - {fileID: 21300000, guid: bae9fa5308514492d8ab2d2430aa5392, type: 3}
+  - {fileID: 21300000, guid: 0afe0b3ed7e7e49d9a45d5dd2129fc50, type: 3}
+  _backgroundColors:
+  - {r: 0.93021417, g: 1, b: 0, a: 1}
+  - {r: 1, g: 0.4481132, b: 0.9010639, a: 1}
+--- !u!1 &1207748987
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1207748988}
+  - component: {fileID: 1207748990}
+  - component: {fileID: 1207748989}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1207748988
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1207748987}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1224364855}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1207748989
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1207748987}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1207748990
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1207748987}
+  m_CullTransparentMesh: 0
+--- !u!1 &1224364854
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1224364855}
+  m_Layer: 5
+  m_Name: Sliding Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1224364855
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1224364854}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1207748988}
+  m_Father: {fileID: 1313037046}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: -20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1257669866
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1257669869}
+  - component: {fileID: 1257669868}
+  - component: {fileID: 1257669867}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1257669867
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1257669866}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &1257669868
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1257669866}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &1257669869
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1257669866}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1195574257}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1313037045
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1313037046}
+  - component: {fileID: 1313037049}
+  - component: {fileID: 1313037048}
+  - component: {fileID: 1313037047}
+  m_Layer: 5
+  m_Name: Scrollbar Vertical
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1313037046
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1313037045}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1224364855}
+  m_Father: {fileID: 1413112495}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 0}
+  m_Pivot: {x: 1, y: 1}
+--- !u!114 &1313037047
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1313037045}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2a4db7a114972834c8e4117be1d82ba3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1207748989}
+  m_HandleRect: {fileID: 1207748988}
+  m_Direction: 2
+  m_Value: 1
+  m_Size: 1
+  m_NumberOfSteps: 0
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1313037048
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1313037045}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1313037049
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1313037045}
+  m_CullTransparentMesh: 0
+--- !u!1 &1413112494
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1413112495}
+  - component: {fileID: 1413112499}
+  - component: {fileID: 1413112498}
+  - component: {fileID: 1413112497}
+  - component: {fileID: 1413112500}
+  m_Layer: 5
+  m_Name: SimpleTable
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1413112495
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1413112494}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1615867753}
+  - {fileID: 1313037046}
+  m_Father: {fileID: 665227623}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1413112497
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1413112494}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1aa08ab6e0800fa44ae55d278d1423e3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Content: {fileID: 1437777802}
+  m_Horizontal: 0
+  m_Vertical: 1
+  m_MovementType: 1
+  m_Elasticity: 0.1
+  m_Inertia: 1
+  m_DecelerationRate: 0.135
+  m_ScrollSensitivity: 1
+  m_Viewport: {fileID: 1615867753}
+  m_HorizontalScrollbar: {fileID: 0}
+  m_VerticalScrollbar: {fileID: 1313037047}
+  m_HorizontalScrollbarVisibility: 2
+  m_VerticalScrollbarVisibility: 0
+  m_HorizontalScrollbarSpacing: -3
+  m_VerticalScrollbarSpacing: -3
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1413112498
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1413112494}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1413112499
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1413112494}
+  m_CullTransparentMesh: 1
+--- !u!114 &1413112500
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1413112494}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00cba7436352e44979a55ad5301f2046, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _scrollRect: {fileID: 1413112497}
+  _viewport: {fileID: 1615867753}
+  _content: {fileID: 1437777802}
+  _direction: 0
+  _useNestedScrollRect: 0
+  _ignoreCellLifeCycle: 0
+  _tag: 0
+  preserveClickEvenDragBegins: 0
+--- !u!1 &1437777801
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1437777802}
+  m_Layer: 5
+  m_Name: Content
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1437777802
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1437777801}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1615867753}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 1334}
+  m_Pivot: {x: 0, y: 1}
+--- !u!1 &1465980651
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1465980652}
+  - component: {fileID: 1465980654}
+  - component: {fileID: 1465980653}
+  m_Layer: 5
+  m_Name: Bg
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1465980652
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1465980651}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 665227623}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1465980653
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1465980651}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.6698113, g: 0.6698113, b: 0.6698113, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1465980654
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1465980651}
+  m_CullTransparentMesh: 0
+--- !u!850595691 &1563366965
+LightingSettings:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Settings.lighting
+  serializedVersion: 9
+  m_EnableBakedLightmaps: 0
+  m_EnableRealtimeLightmaps: 0
+  m_RealtimeEnvironmentLighting: 1
+  m_BounceScale: 1
+  m_AlbedoBoost: 1
+  m_IndirectOutputScale: 1
+  m_UsingShadowmask: 1
+  m_BakeBackend: 2
+  m_LightmapMaxSize: 1024
+  m_LightmapSizeFixed: 0
+  m_UseMipmapLimits: 1
+  m_BakeResolution: 40
+  m_Padding: 2
+  m_LightmapCompression: 2
+  m_AO: 0
+  m_AOMaxDistance: 1
+  m_CompAOExponent: 1
+  m_CompAOExponentDirect: 0
+  m_ExtractAO: 0
+  m_MixedBakeMode: 2
+  m_LightmapsBakeMode: 1
+  m_FilterMode: 1
+  m_LightmapParameters: {fileID: 15204, guid: 0000000000000000f000000000000000, type: 0}
+  m_ExportTrainingData: 0
+  m_EnableWorkerProcessBaking: 1
+  m_TrainingDataDestination: TrainingData
+  m_RealtimeResolution: 2
+  m_ForceWhiteAlbedo: 0
+  m_ForceUpdates: 0
+  m_PVRCulling: 1
+  m_PVRSampling: 1
+  m_PVRDirectSampleCount: 32
+  m_PVRSampleCount: 512
+  m_PVREnvironmentSampleCount: 512
+  m_PVREnvironmentReferencePointCount: 2048
+  m_LightProbeSampleCountMultiplier: 4
+  m_PVRBounces: 2
+  m_PVRMinBounces: 2
+  m_PVREnvironmentImportanceSampling: 0
+  m_PVRFilteringMode: 2
+  m_PVRDenoiserTypeDirect: 0
+  m_PVRDenoiserTypeIndirect: 0
+  m_PVRDenoiserTypeAO: 0
+  m_PVRFilterTypeDirect: 0
+  m_PVRFilterTypeIndirect: 0
+  m_PVRFilterTypeAO: 0
+  m_PVRFilteringGaussRadiusDirect: 1
+  m_PVRFilteringGaussRadiusIndirect: 5
+  m_PVRFilteringGaussRadiusAO: 2
+  m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+  m_PVRFilteringAtrousPositionSigmaIndirect: 2
+  m_PVRFilteringAtrousPositionSigmaAO: 1
+  m_RespectSceneVisibilityWhenBakingGI: 0
+--- !u!1 &1615867752
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1615867753}
+  - component: {fileID: 1615867756}
+  - component: {fileID: 1615867755}
+  - component: {fileID: 1615867754}
+  m_Layer: 5
+  m_Name: Viewport
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1615867753
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615867752}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1437777802}
+  m_Father: {fileID: 1413112495}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0.000061035156}
+  m_SizeDelta: {x: -19.975, y: 0}
+  m_Pivot: {x: 0, y: 1}
+--- !u!114 &1615867754
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615867752}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31a19414c41e5ae4aae2af33fee712f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowMaskGraphic: 0
+--- !u!114 &1615867755
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615867752}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10917, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1615867756
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615867752}
+  m_CullTransparentMesh: 1
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1195574257}

--- a/Assets/UIKit/Samples/8_LoopTable/8_LoopTableScene.unity.meta
+++ b/Assets/UIKit/Samples/8_LoopTable/8_LoopTableScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8b28ac4ea1954fbf9825deb04761f5dd
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/UIKit/Samples/8_LoopTable/Scripts.meta
+++ b/Assets/UIKit/Samples/8_LoopTable/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b1520916f90a4a70afb9945d49c751d6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/UIKit/Samples/8_LoopTable/Scripts/LoopingTableScene.cs
+++ b/Assets/UIKit/Samples/8_LoopTable/Scripts/LoopingTableScene.cs
@@ -1,0 +1,57 @@
+using UnityEngine;
+
+namespace UIKit.Samples
+{
+        public class LoopingTableScene : MonoBehaviour, IUITableViewDataSource, IUITableViewDelegate
+        {
+                [SerializeField] UITableView _tableView;
+                [SerializeField] SimpleCell _cellPrefab;
+
+                [SerializeField] Sprite[] _iconSprites;
+                [SerializeField] Color[] _backgroundColors;
+
+                void Start()
+                {
+                        _tableView.enableLooping = true;
+                        _tableView.dataSource = this;
+                        _tableView.@delegate = this;
+                        _tableView.ReloadData();
+                }
+
+                #region IUITableViewDataSource
+                public UITableViewCell CellAtIndexInTableView(UITableView tableView, int index)
+                {
+                        return _tableView.ReuseOrCreateCell(_cellPrefab);
+                }
+
+                public int NumberOfCellsInTableView(UITableView tableView)
+                {
+                        return 200;
+                }
+
+                public float LengthForCellInTableView(UITableView tableView, int index)
+                {
+                        return index % 2 == 0 ? 150 : 200;
+                }
+                #endregion
+
+                #region IUITableViewDelegate
+                public void CellAtIndexInTableViewWillAppear(UITableView tableView, int index)
+                {
+                        var cell = tableView.GetLoadedCell<SimpleCell>(index);
+                        cell.text.text = $"Cell Index: {index}";
+                        cell.text.color = index % _backgroundColors.Length == 0 ? Color.black : Color.white;
+                        cell.icon.sprite = _iconSprites[index % _iconSprites.Length];
+                        cell.background.color = _backgroundColors[index % _backgroundColors.Length];
+                }
+
+                public void CellAtIndexInTableViewDidDisappear(UITableView tableView, int index)
+                {
+                        var cell = tableView.GetLoadedCell<SimpleCell>(index);
+                        cell.text.text = string.Empty;
+                        cell.icon.sprite = null;
+                        cell.background.color = Color.white;
+                }
+                #endregion
+        }
+}

--- a/Assets/UIKit/Samples/8_LoopTable/Scripts/LoopingTableScene.cs
+++ b/Assets/UIKit/Samples/8_LoopTable/Scripts/LoopingTableScene.cs
@@ -26,7 +26,7 @@ namespace UIKit.Samples
 
                 public int NumberOfCellsInTableView(UITableView tableView)
                 {
-                        return 200;
+                        return 30;
                 }
 
                 public float LengthForCellInTableView(UITableView tableView, int index)

--- a/Assets/UIKit/Samples/8_LoopTable/Scripts/LoopingTableScene.cs.meta
+++ b/Assets/UIKit/Samples/8_LoopTable/Scripts/LoopingTableScene.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 212b90bbc3c0467da185f68c936e1a07
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/UIKit/UITableView/UITableView.cs
+++ b/Assets/UIKit/UITableView/UITableView.cs
@@ -346,43 +346,43 @@ namespace UIKit
 			_onNormalizedPositionChangedCalled = true;
 		       if (_holders.Count <= 0) return;
 		       if (_enableLooping) {
-			       var velocity = _scrollRect.velocity;
-			       if (_direction.IsVertical()) {
-				       var contentSize = _content.rect.height;
-				       var viewportSize = _viewport.rect.height;
-				       if (contentSize > viewportSize) {
-					       var threshold = viewportSize / contentSize;
-					       var wrapAmount = 1f - 2f * threshold;
-					       if (normalizedPosition.y < threshold) {
-						       normalizedPosition.y += wrapAmount;
-						       _scrollRect.normalizedPosition = normalizedPosition;
-						       _scrollRect.velocity = velocity;
-					       } else if (normalizedPosition.y > 1f - threshold) {
-						       normalizedPosition.y -= wrapAmount;
-						       _scrollRect.normalizedPosition = normalizedPosition;
-						       _scrollRect.velocity = velocity;
-					       }
-				       }
-			       } else {
-				       var contentSize = _content.rect.width;
-				       var viewportSize = _viewport.rect.width;
-				       if (contentSize > viewportSize) {
-					       var threshold = viewportSize / contentSize;
-					       var wrapAmount = 1f - 2f * threshold;
-					       if (normalizedPosition.x < threshold) {
-						       normalizedPosition.x += wrapAmount;
-						       _scrollRect.normalizedPosition = normalizedPosition;
-						       _scrollRect.velocity = velocity;
-					       } else if (normalizedPosition.x > 1f - threshold) {
-						       normalizedPosition.x -= wrapAmount;
-						       _scrollRect.normalizedPosition = normalizedPosition;
-						       _scrollRect.velocity = velocity;
-					       }
-				       }
-			       }
-			       // Use updated normalized position after wrapping
-			       normalizedPosition = _scrollRect.normalizedPosition;
-		       }
+                               var velocity = _scrollRect.velocity;
+                               if (_direction.IsVertical()) {
+                                       var contentSize = _content.rect.height;
+                                       var viewportSize = _viewport.rect.height;
+                                       if (contentSize > viewportSize) {
+                                               var threshold = viewportSize / (contentSize - viewportSize);
+                                               var offset = 1f - threshold;
+                                               if (normalizedPosition.y < threshold) {
+                                                       normalizedPosition.y += offset;
+                                                       _scrollRect.normalizedPosition = normalizedPosition;
+                                                       _scrollRect.velocity = velocity;
+                                               } else if (normalizedPosition.y > 1f - threshold) {
+                                                       normalizedPosition.y -= offset;
+                                                       _scrollRect.normalizedPosition = normalizedPosition;
+                                                       _scrollRect.velocity = velocity;
+                                               }
+                                       }
+                               } else {
+                                       var contentSize = _content.rect.width;
+                                       var viewportSize = _viewport.rect.width;
+                                       if (contentSize > viewportSize) {
+                                               var threshold = viewportSize / (contentSize - viewportSize);
+                                               var offset = 1f - threshold;
+                                               if (normalizedPosition.x < threshold) {
+                                                       normalizedPosition.x += offset;
+                                                       _scrollRect.normalizedPosition = normalizedPosition;
+                                                       _scrollRect.velocity = velocity;
+                                               } else if (normalizedPosition.x > 1f - threshold) {
+                                                       normalizedPosition.x -= offset;
+                                                       _scrollRect.normalizedPosition = normalizedPosition;
+                                                       _scrollRect.velocity = velocity;
+                                               }
+                                       }
+                               }
+                               // Use updated normalized position after wrapping
+                               normalizedPosition = _scrollRect.normalizedPosition;
+                       }
 		       ReloadCells(normalizedPosition, false);
 		       if (!_enableLooping)
 			       DetectAndNotifyReachableStatus();

--- a/Assets/UIKit/UITableView/UITableView.cs
+++ b/Assets/UIKit/UITableView/UITableView.cs
@@ -41,10 +41,10 @@ namespace UIKit
 			}
 		}
 
-                public bool enableLooping {
-                        get => _enableLooping;
-                        set => _enableLooping = value;
-                }
+		public bool enableLooping {
+			get => _enableLooping;
+			set => _enableLooping = value;
+		}
 
 		public UITableViewDirection direction {
 			get => _direction;
@@ -84,8 +84,8 @@ namespace UIKit
 #endif
 		[Header("If selected, \nthe UITableViewCellLifeCycle will be ignored, \nand all cells will be loaded at once.")]
 		[SerializeField] bool _ignoreCellLifeCycle;
-                [Header("Enable looping of scroll content.")]
-                [SerializeField] bool _enableLooping;
+		[Header("Enable looping of scroll content.")]
+		[SerializeField] bool _enableLooping;
 		/// <summary> For distinguishing between table views. For example, using two table views with a single datasource. </summary>
 		[Header("For distinguishing between table views. \nFor example, using two table views \nwith a single datasource.")]
 		public int _tag;
@@ -218,52 +218,52 @@ namespace UIKit
 			return new Vector2Int(_foundStartIndex, _foundEndIndex);
 		}
 
-                int FindIndexOfCellAtPosition(Vector2 targetPosition, int searchFromIndex, int lastFoundIndex)
-                {
-                        var length = _holders.Count;
-                        var isVertical = _direction.IsVertical();
-                        var targetPositionXY = isVertical ? targetPosition.y : targetPosition.x;
-                        var hintIndex = Mathf.Clamp(lastFoundIndex, 0, length - 1); // Clamp hint to valid range:
+		int FindIndexOfCellAtPosition(Vector2 targetPosition, int searchFromIndex, int lastFoundIndex)
+		{
+			var length = _holders.Count;
+			var isVertical = _direction.IsVertical();
+			var targetPositionXY = isVertical ? targetPosition.y : targetPosition.x;
+			var hintIndex = Mathf.Clamp(lastFoundIndex, 0, length - 1); // Clamp hint to valid range:
 
-                        // 1) Quick check around the hint (±1), in case scrolling is incremental:
-                        if (_holders[hintIndex].rowPosition <= targetPositionXY) { // scroll up
-                                if (hintIndex == length - 1 || _holders[hintIndex + 1].rowPosition > targetPositionXY) {
-                                        return _enableLooping && length > 0 ? hintIndex % length : hintIndex;
-                                }
-                        } else if (hintIndex > 0 && _holders[hintIndex - 1].rowPosition <= targetPositionXY) {
-                                var idx = hintIndex - 1;
-                                return _enableLooping && length > 0 ? idx % length : idx;
-                        }
+			// 1) Quick check around the hint (±1), in case scrolling is incremental:
+			if (_holders[hintIndex].rowPosition <= targetPositionXY) { // scroll up
+				if (hintIndex == length - 1 || _holders[hintIndex + 1].rowPosition > targetPositionXY) {
+					return _enableLooping && length > 0 ? hintIndex % length : hintIndex;
+				}
+			} else if (hintIndex > 0 && _holders[hintIndex - 1].rowPosition <= targetPositionXY) {
+				var idx = hintIndex - 1;
+				return _enableLooping && length > 0 ? idx % length : idx;
+			}
 
-                        // 2) Fallback: full binary search
-                        var result = FindIndexOfCellAtPosition(targetPositionXY, searchFromIndex, length);
-                        if (_enableLooping && length > 0) result %= length;
-                        return result;
-                }
+			// 2) Fallback: full binary search
+			var result = FindIndexOfCellAtPosition(targetPositionXY, searchFromIndex, length);
+			if (_enableLooping && length > 0) result %= length;
+			return result;
+		}
 
-                int FindIndexOfCellAtPosition(float targetPositionXY, int searchFromIndex, int length)
-                {
-                        while (searchFromIndex < length) {
-                                var midIndex = (searchFromIndex + length) >> 1;
-                                if (_holders[midIndex].rowPosition > targetPositionXY) {
-                                        length = midIndex;
-                                        continue;
-                                }
-                                searchFromIndex = midIndex + 1;
-                        }
-                        var result = Math.Max(0, searchFromIndex - 1);
-                        if (_enableLooping && length > 0) result %= length;
-                        return result;
-                }
+		int FindIndexOfCellAtPosition(float targetPositionXY, int searchFromIndex, int length)
+		{
+			while (searchFromIndex < length) {
+				var midIndex = (searchFromIndex + length) >> 1;
+				if (_holders[midIndex].rowPosition > targetPositionXY) {
+					length = midIndex;
+					continue;
+				}
+				searchFromIndex = midIndex + 1;
+			}
+			var result = Math.Max(0, searchFromIndex - 1);
+			if (_enableLooping && length > 0) result %= length;
+			return result;
+		}
 
-                int FindIndexOfCellAtCalibrationPoint(Vector2 calibrationPoint, Vector2 normalizedPosition)
-                {
-                        var np = _direction.IsTopToBottomOrRightToLeft() ? Vector2.one - normalizedPosition : normalizedPosition;
-                        var tvPos = np * _content.rect.size - _viewport.rect.size * (np - calibrationPoint);
-                        var index = FindIndexOfCellAtPosition(_direction.IsVertical() ? tvPos.y : tvPos.x, 0, _holders.Count);
-                        if (_enableLooping && _holders.Count > 0) index %= _holders.Count;
-                        return index;
-                }
+		int FindIndexOfCellAtCalibrationPoint(Vector2 calibrationPoint, Vector2 normalizedPosition)
+		{
+			var np = _direction.IsTopToBottomOrRightToLeft() ? Vector2.one - normalizedPosition : normalizedPosition;
+			var tvPos = np * _content.rect.size - _viewport.rect.size * (np - calibrationPoint);
+			var index = FindIndexOfCellAtPosition(_direction.IsVertical() ? tvPos.y : tvPos.x, 0, _holders.Count);
+			if (_enableLooping && _holders.Count > 0) index %= _holders.Count;
+			return index;
+		}
 
 		void ResizeContent(int numberOfCells, bool forceUpdateContent)
 		{
@@ -341,32 +341,52 @@ namespace UIKit
 				: new Vector2(cumulativeRowLength, _content.sizeDelta.y);
 		}
 
-                void OnNormalizedPositionChanged(Vector2 normalizedPosition)
-                {
-                        _onNormalizedPositionChangedCalled = true;
-                       if (_holders.Count <= 0) return;
-                       if (_enableLooping) {
-                               var velocity = _scrollRect.velocity;
-                               if (_direction.IsVertical()) {
-                                       if (normalizedPosition.y < 0f || normalizedPosition.y > 1f) {
-                                               normalizedPosition.y = normalizedPosition.y < 0f ? normalizedPosition.y + 1f : normalizedPosition.y - 1f;
-                                               _scrollRect.normalizedPosition = normalizedPosition;
-                                               _scrollRect.velocity = velocity;
-                                       }
-                               } else {
-                                       if (normalizedPosition.x < 0f || normalizedPosition.x > 1f) {
-                                               normalizedPosition.x = normalizedPosition.x < 0f ? normalizedPosition.x + 1f : normalizedPosition.x - 1f;
-                                               _scrollRect.normalizedPosition = normalizedPosition;
-                                               _scrollRect.velocity = velocity;
-                                       }
-                               }
-                               // Use updated normalized position after wrapping
-                               normalizedPosition = _scrollRect.normalizedPosition;
-                       }
-                       ReloadCells(normalizedPosition, false);
-                       if (!_enableLooping)
-                               DetectAndNotifyReachableStatus();
-               }
+		void OnNormalizedPositionChanged(Vector2 normalizedPosition)
+		{
+			_onNormalizedPositionChangedCalled = true;
+		       if (_holders.Count <= 0) return;
+		       if (_enableLooping) {
+			       var velocity = _scrollRect.velocity;
+			       if (_direction.IsVertical()) {
+				       var contentSize = _content.rect.height;
+				       var viewportSize = _viewport.rect.height;
+				       if (contentSize > viewportSize) {
+					       var threshold = viewportSize / contentSize;
+					       var wrapAmount = 1f - 2f * threshold;
+					       if (normalizedPosition.y < threshold) {
+						       normalizedPosition.y += wrapAmount;
+						       _scrollRect.normalizedPosition = normalizedPosition;
+						       _scrollRect.velocity = velocity;
+					       } else if (normalizedPosition.y > 1f - threshold) {
+						       normalizedPosition.y -= wrapAmount;
+						       _scrollRect.normalizedPosition = normalizedPosition;
+						       _scrollRect.velocity = velocity;
+					       }
+				       }
+			       } else {
+				       var contentSize = _content.rect.width;
+				       var viewportSize = _viewport.rect.width;
+				       if (contentSize > viewportSize) {
+					       var threshold = viewportSize / contentSize;
+					       var wrapAmount = 1f - 2f * threshold;
+					       if (normalizedPosition.x < threshold) {
+						       normalizedPosition.x += wrapAmount;
+						       _scrollRect.normalizedPosition = normalizedPosition;
+						       _scrollRect.velocity = velocity;
+					       } else if (normalizedPosition.x > 1f - threshold) {
+						       normalizedPosition.x -= wrapAmount;
+						       _scrollRect.normalizedPosition = normalizedPosition;
+						       _scrollRect.velocity = velocity;
+					       }
+				       }
+			       }
+			       // Use updated normalized position after wrapping
+			       normalizedPosition = _scrollRect.normalizedPosition;
+		       }
+		       ReloadCells(normalizedPosition, false);
+		       if (!_enableLooping)
+			       DetectAndNotifyReachableStatus();
+	       }
 		void ReloadCells(Vector2 normalizedPosition, bool alwaysRearrangeCell)
 		{
 			var range = RecalculateVisibleRange(normalizedPosition);
@@ -541,18 +561,18 @@ namespace UIKit
 			if (!_onNormalizedPositionChangedCalled)
 				ReloadCells(_scrollRect.normalizedPosition, false);
 
-                        if (!_enableLooping) {
-                                // Recalculate if the content is reaching view port's boundary.
-                                CalculateReachableStatus(out var curIsReachingTopmostOrRightmost, out var curIsReachingBottommostOrLeftmost);
-                                _isReachingTopmostOrRightmost = curIsReachingTopmostOrRightmost;
-                                _isReachingBottommostOrLeftmost = curIsReachingBottommostOrLeftmost;
-                        }
+			if (!_enableLooping) {
+				// Recalculate if the content is reaching view port's boundary.
+				CalculateReachableStatus(out var curIsReachingTopmostOrRightmost, out var curIsReachingBottommostOrLeftmost);
+				_isReachingTopmostOrRightmost = curIsReachingTopmostOrRightmost;
+				_isReachingBottommostOrLeftmost = curIsReachingBottommostOrLeftmost;
+			}
 		}
 
 		///<summary> Detect if the table view has reached or left the topmost/rightmost or bottommost/leftmost</summary>
 		void DetectAndNotifyReachableStatus()
 		{
-                        if (_enableLooping || this.reachable == null) return;
+			if (_enableLooping || this.reachable == null) return;
 			CalculateReachableStatus(out var curIsReachingTopmostOrRightmost, out var curIsReachingBottommostOrLeftmost);
 			if (!_isReachingTopmostOrRightmost && curIsReachingTopmostOrRightmost) {
 				this.reachable.TableViewReachedTopmostOrRightmost(this);
@@ -572,8 +592,8 @@ namespace UIKit
 
 		void CalculateReachableStatus(out bool isReachingTopmostOrRightmost, out bool isReachingBottommostOrLeftmost)
 		{
-                        isReachingTopmostOrRightmost = isReachingBottommostOrLeftmost = false;
-                        if (_enableLooping || this.reachable == null) return;
+			isReachingTopmostOrRightmost = isReachingBottommostOrLeftmost = false;
+			if (_enableLooping || this.reachable == null) return;
 			var upperTolerance = this.reachable.TableViewReachableEdgeTolerance(this);
 			float curPosition, lowerTolerance;
 			var deltaSize = _content.rect.size - _viewport.rect.size;
@@ -609,7 +629,7 @@ namespace UIKit
 			ResizeContent(0, false);
 		}
 
-		/// <summary> Replace the current cell at row with a new cell.  </summary>
+		/// <summary> Replace the current cell at row with a new cell.	</summary>
 		public void ReloadDataAt(int index) 
 		{
 			RearrangeData();

--- a/Assets/UIKit/UITableView/UITableView.cs
+++ b/Assets/UIKit/UITableView/UITableView.cs
@@ -344,31 +344,29 @@ namespace UIKit
                 void OnNormalizedPositionChanged(Vector2 normalizedPosition)
                 {
                         _onNormalizedPositionChangedCalled = true;
-                        if (_holders.Count <= 0) return;
-                        if (_enableLooping) {
-                                const float epsilon = 0.0001f;
-                                if (_direction.IsVertical()) {
-                                        if (normalizedPosition.y <= 0f) {
-                                                normalizedPosition.y = 1f - epsilon;
-                                                _scrollRect.normalizedPosition = normalizedPosition;
-                                        } else if (normalizedPosition.y >= 1f) {
-                                                normalizedPosition.y = epsilon;
-                                                _scrollRect.normalizedPosition = normalizedPosition;
-                                        }
-                                } else {
-                                        if (normalizedPosition.x <= 0f) {
-                                                normalizedPosition.x = 1f - epsilon;
-                                                _scrollRect.normalizedPosition = normalizedPosition;
-                                        } else if (normalizedPosition.x >= 1f) {
-                                                normalizedPosition.x = epsilon;
-                                                _scrollRect.normalizedPosition = normalizedPosition;
-                                        }
-                                }
-                        }
-                        ReloadCells(normalizedPosition, false);
-                        if (!_enableLooping)
-                                DetectAndNotifyReachableStatus();
-                }
+                       if (_holders.Count <= 0) return;
+                       if (_enableLooping) {
+                               var velocity = _scrollRect.velocity;
+                               if (_direction.IsVertical()) {
+                                       if (normalizedPosition.y < 0f || normalizedPosition.y > 1f) {
+                                               normalizedPosition.y = normalizedPosition.y < 0f ? normalizedPosition.y + 1f : normalizedPosition.y - 1f;
+                                               _scrollRect.normalizedPosition = normalizedPosition;
+                                               _scrollRect.velocity = velocity;
+                                       }
+                               } else {
+                                       if (normalizedPosition.x < 0f || normalizedPosition.x > 1f) {
+                                               normalizedPosition.x = normalizedPosition.x < 0f ? normalizedPosition.x + 1f : normalizedPosition.x - 1f;
+                                               _scrollRect.normalizedPosition = normalizedPosition;
+                                               _scrollRect.velocity = velocity;
+                                       }
+                               }
+                               // Use updated normalized position after wrapping
+                               normalizedPosition = _scrollRect.normalizedPosition;
+                       }
+                       ReloadCells(normalizedPosition, false);
+                       if (!_enableLooping)
+                               DetectAndNotifyReachableStatus();
+               }
 		void ReloadCells(Vector2 normalizedPosition, bool alwaysRearrangeCell)
 		{
 			var range = RecalculateVisibleRange(normalizedPosition);

--- a/Assets/UIKit/UITableView/UITableView.cs
+++ b/Assets/UIKit/UITableView/UITableView.cs
@@ -41,6 +41,11 @@ namespace UIKit
 			}
 		}
 
+                public bool enableLooping {
+                        get => _enableLooping;
+                        set => _enableLooping = value;
+                }
+
 		public UITableViewDirection direction {
 			get => _direction;
 			set {
@@ -79,6 +84,8 @@ namespace UIKit
 #endif
 		[Header("If selected, \nthe UITableViewCellLifeCycle will be ignored, \nand all cells will be loaded at once.")]
 		[SerializeField] bool _ignoreCellLifeCycle;
+                [Header("Enable looping of scroll content.")]
+                [SerializeField] bool _enableLooping;
 		/// <summary> For distinguishing between table views. For example, using two table views with a single datasource. </summary>
 		[Header("For distinguishing between table views. \nFor example, using two table views \nwith a single datasource.")]
 		public int _tag;
@@ -211,45 +218,52 @@ namespace UIKit
 			return new Vector2Int(_foundStartIndex, _foundEndIndex);
 		}
 
-		int FindIndexOfCellAtPosition(Vector2 targetPosition, int searchFromIndex, int lastFoundIndex)
-		{
-			var length = _holders.Count;
-			var isVertical = _direction.IsVertical();
-			var targetPositionXY = isVertical ? targetPosition.y : targetPosition.x;
-			var hintIndex = Mathf.Clamp(lastFoundIndex, 0, length - 1); // Clamp hint to valid range:
+                int FindIndexOfCellAtPosition(Vector2 targetPosition, int searchFromIndex, int lastFoundIndex)
+                {
+                        var length = _holders.Count;
+                        var isVertical = _direction.IsVertical();
+                        var targetPositionXY = isVertical ? targetPosition.y : targetPosition.x;
+                        var hintIndex = Mathf.Clamp(lastFoundIndex, 0, length - 1); // Clamp hint to valid range:
 
-			// 1) Quick check around the hint (±1), in case scrolling is incremental:
-			if (_holders[hintIndex].rowPosition <= targetPositionXY) { // scroll up
-				if (hintIndex == length - 1 || _holders[hintIndex + 1].rowPosition > targetPositionXY) {
-					return hintIndex;
-				} 
-			} else if (hintIndex > 0 && _holders[hintIndex - 1].rowPosition <= targetPositionXY) {
-				return hintIndex - 1;
-			}
+                        // 1) Quick check around the hint (±1), in case scrolling is incremental:
+                        if (_holders[hintIndex].rowPosition <= targetPositionXY) { // scroll up
+                                if (hintIndex == length - 1 || _holders[hintIndex + 1].rowPosition > targetPositionXY) {
+                                        return _enableLooping && length > 0 ? hintIndex % length : hintIndex;
+                                }
+                        } else if (hintIndex > 0 && _holders[hintIndex - 1].rowPosition <= targetPositionXY) {
+                                var idx = hintIndex - 1;
+                                return _enableLooping && length > 0 ? idx % length : idx;
+                        }
 
-			// 2) Fallback: full binary search
-			return FindIndexOfCellAtPosition(targetPositionXY, searchFromIndex, length);
-		}
+                        // 2) Fallback: full binary search
+                        var result = FindIndexOfCellAtPosition(targetPositionXY, searchFromIndex, length);
+                        if (_enableLooping && length > 0) result %= length;
+                        return result;
+                }
 
-		int FindIndexOfCellAtPosition(float targetPositionXY, int searchFromIndex, int length)
-		{
-			while (searchFromIndex < length) {
-				var midIndex = (searchFromIndex + length) >> 1;
-				if (_holders[midIndex].rowPosition > targetPositionXY) {
-					length = midIndex;
-					continue;
-				}
-				searchFromIndex = midIndex + 1;
-			}
-			return Math.Max(0, searchFromIndex - 1);
-		}
+                int FindIndexOfCellAtPosition(float targetPositionXY, int searchFromIndex, int length)
+                {
+                        while (searchFromIndex < length) {
+                                var midIndex = (searchFromIndex + length) >> 1;
+                                if (_holders[midIndex].rowPosition > targetPositionXY) {
+                                        length = midIndex;
+                                        continue;
+                                }
+                                searchFromIndex = midIndex + 1;
+                        }
+                        var result = Math.Max(0, searchFromIndex - 1);
+                        if (_enableLooping && length > 0) result %= length;
+                        return result;
+                }
 
-		int FindIndexOfCellAtCalibrationPoint(Vector2 calibrationPoint, Vector2 normalizedPosition)
-		{
-			var np = _direction.IsTopToBottomOrRightToLeft() ? Vector2.one - normalizedPosition : normalizedPosition;
-			var tvPos = np * _content.rect.size - _viewport.rect.size * (np - calibrationPoint);
-			return FindIndexOfCellAtPosition(_direction.IsVertical() ? tvPos.y : tvPos.x, 0, _holders.Count);
-		}
+                int FindIndexOfCellAtCalibrationPoint(Vector2 calibrationPoint, Vector2 normalizedPosition)
+                {
+                        var np = _direction.IsTopToBottomOrRightToLeft() ? Vector2.one - normalizedPosition : normalizedPosition;
+                        var tvPos = np * _content.rect.size - _viewport.rect.size * (np - calibrationPoint);
+                        var index = FindIndexOfCellAtPosition(_direction.IsVertical() ? tvPos.y : tvPos.x, 0, _holders.Count);
+                        if (_enableLooping && _holders.Count > 0) index %= _holders.Count;
+                        return index;
+                }
 
 		void ResizeContent(int numberOfCells, bool forceUpdateContent)
 		{
@@ -327,14 +341,34 @@ namespace UIKit
 				: new Vector2(cumulativeRowLength, _content.sizeDelta.y);
 		}
 
-		void OnNormalizedPositionChanged(Vector2 normalizedPosition)
-		{
-			_onNormalizedPositionChangedCalled = true;
-			if (_holders.Count <= 0) return;
-			ReloadCells(normalizedPosition, false);
-			DetectAndNotifyReachableStatus();
-		}
-
+                void OnNormalizedPositionChanged(Vector2 normalizedPosition)
+                {
+                        _onNormalizedPositionChangedCalled = true;
+                        if (_holders.Count <= 0) return;
+                        if (_enableLooping) {
+                                const float epsilon = 0.0001f;
+                                if (_direction.IsVertical()) {
+                                        if (normalizedPosition.y <= 0f) {
+                                                normalizedPosition.y = 1f - epsilon;
+                                                _scrollRect.normalizedPosition = normalizedPosition;
+                                        } else if (normalizedPosition.y >= 1f) {
+                                                normalizedPosition.y = epsilon;
+                                                _scrollRect.normalizedPosition = normalizedPosition;
+                                        }
+                                } else {
+                                        if (normalizedPosition.x <= 0f) {
+                                                normalizedPosition.x = 1f - epsilon;
+                                                _scrollRect.normalizedPosition = normalizedPosition;
+                                        } else if (normalizedPosition.x >= 1f) {
+                                                normalizedPosition.x = epsilon;
+                                                _scrollRect.normalizedPosition = normalizedPosition;
+                                        }
+                                }
+                        }
+                        ReloadCells(normalizedPosition, false);
+                        if (!_enableLooping)
+                                DetectAndNotifyReachableStatus();
+                }
 		void ReloadCells(Vector2 normalizedPosition, bool alwaysRearrangeCell)
 		{
 			var range = RecalculateVisibleRange(normalizedPosition);
@@ -509,16 +543,18 @@ namespace UIKit
 			if (!_onNormalizedPositionChangedCalled)
 				ReloadCells(_scrollRect.normalizedPosition, false);
 
-			// Recalculate if the content is reaching view port's boundary.
-			CalculateReachableStatus(out var curIsReachingTopmostOrRightmost, out var curIsReachingBottommostOrLeftmost);
-			_isReachingTopmostOrRightmost = curIsReachingTopmostOrRightmost;
-			_isReachingBottommostOrLeftmost = curIsReachingBottommostOrLeftmost;
+                        if (!_enableLooping) {
+                                // Recalculate if the content is reaching view port's boundary.
+                                CalculateReachableStatus(out var curIsReachingTopmostOrRightmost, out var curIsReachingBottommostOrLeftmost);
+                                _isReachingTopmostOrRightmost = curIsReachingTopmostOrRightmost;
+                                _isReachingBottommostOrLeftmost = curIsReachingBottommostOrLeftmost;
+                        }
 		}
 
 		///<summary> Detect if the table view has reached or left the topmost/rightmost or bottommost/leftmost</summary>
 		void DetectAndNotifyReachableStatus()
 		{
-			if (this.reachable == null) return;
+                        if (_enableLooping || this.reachable == null) return;
 			CalculateReachableStatus(out var curIsReachingTopmostOrRightmost, out var curIsReachingBottommostOrLeftmost);
 			if (!_isReachingTopmostOrRightmost && curIsReachingTopmostOrRightmost) {
 				this.reachable.TableViewReachedTopmostOrRightmost(this);
@@ -538,8 +574,8 @@ namespace UIKit
 
 		void CalculateReachableStatus(out bool isReachingTopmostOrRightmost, out bool isReachingBottommostOrLeftmost)
 		{
-			isReachingTopmostOrRightmost = isReachingBottommostOrLeftmost = false;
-			if (this.reachable == null) return;
+                        isReachingTopmostOrRightmost = isReachingBottommostOrLeftmost = false;
+                        if (_enableLooping || this.reachable == null) return;
 			var upperTolerance = this.reachable.TableViewReachableEdgeTolerance(this);
 			float curPosition, lowerTolerance;
 			var deltaSize = _content.rect.size - _viewport.rect.size;

--- a/Assets/UIKit/package.json
+++ b/Assets/UIKit/package.json
@@ -49,6 +49,11 @@
             "displayName": "7_SnappingTable",
             "description": "7_Snapping table.",
             "path": "Samples/7_SnappingTable"
+        },
+        {
+            "displayName": "8_LoopTable",
+            "description": "Looping table.",
+            "path": "Samples/8_LoopTable"
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ For example
 ![](sample_snapping.gif) | ![](sample_expend.gif) | ![](sample_endless_grid.gif) |
 | Changeable Grid | Draggable Grid | Deletable Grid |
 ![](sample_changeable_grid.gif) | ![](sample_grid_drag.gif) | ![](sample_grid_del.gif) |
+| Looping Table |  |  |
+![](sample_endless_table.gif) |  |  |
+To enable looping behaviour, set `enableLooping` to true on `UITableView`. The sample scene `8_LoopTable` demonstrates this feature.
 
 
 # Why I need this?


### PR DESCRIPTION
## Summary
- add `enableLooping` option to UITableView for infinite scroll
- reposition ScrollRect and wrap cell indices when looping
- include new LoopTable sample and docs

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68975af64010833099fc33fa909d3c95